### PR TITLE
Add broker addr seq regexp

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,9 @@
 name: build
 
 on:
-  push:
+  pull_request:
     branches:
-      - '**'
+      - master
 
 jobs:
   build:

--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -103,6 +103,7 @@ func initFlags() {
 	Server.Flags().IntVar(&c.Proxy.ListenerReadBufferSize, "proxy-listener-read-buffer-size", 0, "Size of the operating system's receive buffer associated with the connection. If zero, system default is used")
 	Server.Flags().IntVar(&c.Proxy.ListenerWriteBufferSize, "proxy-listener-write-buffer-size", 0, "Sets the size of the operating system's transmit buffer associated with the connection. If zero, system default is used")
 	Server.Flags().DurationVar(&c.Proxy.ListenerKeepAlive, "proxy-listener-keep-alive", 60*time.Second, "Keep alive period for an active network connection. If zero, keep-alives are disabled")
+	Server.Flags().StringVar(&c.Proxy.BrokerAddressSequenceRegexp, "broker-address-sequence-regexp", "", "We can extract a seq num from the broker addr via the regexp. And add DynamicSequentialMinPort to it to get the listener port.")
 
 	Server.Flags().BoolVar(&c.Proxy.TLS.Enable, "proxy-listener-tls-enable", false, "Whether or not to use TLS listener")
 	Server.Flags().DurationVar(&c.Proxy.TLS.Refresh, "proxy-listener-tls-refresh", 0*time.Second, "Interval for refreshing server TLS certificates. If set to zero, the refresh watch is disabled")

--- a/config/config.go
+++ b/config/config.go
@@ -74,20 +74,21 @@ type Config struct {
 		MsgFiledName   string
 	}
 	Proxy struct {
-		DefaultListenerIP         string
-		BootstrapServers          []ListenerConfig
-		ExternalServers           []ListenerConfig
-		DeterministicListeners    bool
-		DialAddressMappings       []DialAddressMapping
-		DisableDynamicListeners   bool
-		DynamicAdvertisedListener string
-		DynamicSequentialMinPort  uint16
-		DynamicSequentialMaxPorts uint16
-		RequestBufferSize         int
-		ResponseBufferSize        int
-		ListenerReadBufferSize    int // SO_RCVBUF
-		ListenerWriteBufferSize   int // SO_SNDBUF
-		ListenerKeepAlive         time.Duration
+		DefaultListenerIP           string
+		BootstrapServers            []ListenerConfig
+		ExternalServers             []ListenerConfig
+		DeterministicListeners      bool
+		DialAddressMappings         []DialAddressMapping
+		DisableDynamicListeners     bool
+		DynamicAdvertisedListener   string
+		DynamicSequentialMinPort    uint16
+		DynamicSequentialMaxPorts   uint16
+		RequestBufferSize           int
+		ResponseBufferSize          int
+		ListenerReadBufferSize      int // SO_RCVBUF
+		ListenerWriteBufferSize     int // SO_SNDBUF
+		ListenerKeepAlive           time.Duration
+		BrokerAddressSequenceRegexp string
 
 		TLS struct {
 			Enable                   bool


### PR DESCRIPTION
Add a new flag `broker-address-sequence-regexp` so that we can extract sequence number from `brokerAddress`,
and get the proxy listener port by adding `DynamicSequentialMinPort`.

It is for the purpose of a same broker could listen same port on different proxy instances.